### PR TITLE
Introduce ClayOven namespace

### DIFF
--- a/bin/clayoven
+++ b/bin/clayoven
@@ -4,21 +4,23 @@ $:.unshift File.join(File.dirname(__FILE__), *%w{ .. lib })
 
 require 'clayoven'
 
-case ARGV[0]
-when "httpd"
-  Httpd.start
-when "imapd"
-  while 1
-    mails = Imapd.poll
-    if not mails.empty?
-      Core.main
-      mails.each { |mail|
-        `git add .`
-        puts `git commit -a -m "#{mail.filename}: new post\n\n#{mail.date}\n#{mail.msgid}"`
-      }
+module ClayOven
+    case ARGV[0]
+    when "httpd"
+        Httpd.start
+    when "imapd"
+        while 1
+            mails = Imapd.poll
+            if not mails.empty?
+                Core.main
+                mails.each { |mail|
+                    `git add .`
+                    puts `git commit -a -m "#{mail.filename}: new post\n\n#{mail.date}\n#{mail.msgid}"`
+                }
+            end
+            sleep 1800
+        end
+    else
+        Core.main
     end
-    sleep 1800
-  end
-else
-  Core.main
 end

--- a/lib/clayoven.rb
+++ b/lib/clayoven.rb
@@ -15,87 +15,89 @@ def when_introduced(filename)
   end
 end
 
-module Core
-  class Page
-    attr_accessor :filename, :permalink, :timestamp, :title, :topic, :body,
-    :paragraphs, :target, :indexfill, :topics
+module ClayOven
+    module Core
+        class Page
+            attr_accessor :filename, :permalink, :timestamp, :title, :topic, :body,
+            :paragraphs, :target, :indexfill, :topics
 
-    def render(topics)
-      @topics = topics
-      @paragraphs = ClayText.process! @body
-      Slim::Engine.set_default_options pretty: true, sort_attrs: false
-      rendered = Slim::Template.new { IO.read("design/template.slim") }.render(self)
-      File.open(@target, mode="w") { |targetio|
-        nbytes = targetio.write(rendered)
-        puts "[GEN] #{@target} (#{nbytes} bytes out)"
-      }
+            def render(topics)
+                @topics = topics
+                @paragraphs = ClayText.process! @body
+                Slim::Engine.set_default_options pretty: true, sort_attrs: false
+                rendered = Slim::Template.new { IO.read("design/template.slim") }.render(self)
+                File.open(@target, mode="w") { |targetio|
+                    nbytes = targetio.write(rendered)
+                    puts "[GEN] #{@target} (#{nbytes} bytes out)"
+                }
+            end
+        end
+
+        class IndexPage < Page
+            def initialize(filename)
+                @filename = filename
+                if @filename == "index"
+                    @permalink = @filename
+                else
+                    @permalink = filename.split(".index")[0]
+                end
+                @topic = @permalink
+                @target = "#{@permalink}.html"
+                @timestamp = when_introduced @filename
+            end
+        end
+
+        class ContentPage < Page
+            attr_accessor :pub_date
+
+            def initialize(filename)
+                @filename = filename
+                @topic, @permalink = @filename.split(":", 2)
+                @target = "#{@permalink}.html"
+                @indexfill = nil
+                @timestamp = when_introduced @filename
+            end
+        end
+
+        def self.main
+            abort "error: index file not found; aborting" if not File.exists? "index"
+
+            config = ConfigData.new
+            all_files = (Dir.entries(".") -
+                         [".", "..", ".clayoven", "design"]).reject { |entry|
+                config.ignore.any? { |pattern| %r{#{pattern}} =~ entry }
+            }
+
+            abort "error: design/template.slim file not found; aborting" if not
+                Dir.entries("design").include? "template.slim"
+
+            index_files = ["index"] + all_files.select { |file| /\.index$/ =~ file }
+            content_files = all_files - index_files
+            topics = index_files.map { |file| file.split(".index")[0] }.uniq
+
+            # Next, look for stray files
+            (content_files.reject { |file| topics.include? (file.split(":", 2)[0]) })
+                .each { |stray_entry|
+                content_files = content_files - [stray_entry]
+                puts "warning: #{stray_entry} is a stray file or directory; ignored"
+            }
+
+            index_pages = index_files.map { |filename| IndexPage.new(filename) }
+            content_pages = content_files.map { |filename| ContentPage.new(filename) }
+
+            # First, fill in all the page attributes
+            (index_pages + content_pages).each { |page|
+                page.title, page.body = (IO.read page.filename).split("\n\n", 2)
+            }
+
+            # Compute the indexfill for indexes
+            topics.each { |topic|
+                topic_index = index_pages.select { |page| page.topic == topic }[0]
+                topic_index.indexfill = content_pages.select { |page|
+                    page.topic == topic }.sort { |a, b| b.timestamp <=> a.timestamp }
+            }
+
+            (index_pages + content_pages).each { |page| page.render topics }
+        end
     end
-  end
-
-  class IndexPage < Page
-    def initialize(filename)
-      @filename = filename
-      if @filename == "index"
-        @permalink = @filename
-      else
-        @permalink = filename.split(".index")[0]
-      end
-      @topic = @permalink
-      @target = "#{@permalink}.html"
-      @timestamp = when_introduced @filename
-    end
-  end
-
-  class ContentPage < Page
-    attr_accessor :pub_date
-
-    def initialize(filename)
-      @filename = filename
-      @topic, @permalink = @filename.split(":", 2)
-      @target = "#{@permalink}.html"
-      @indexfill = nil
-      @timestamp = when_introduced @filename
-    end
-  end
-
-  def self.main
-    abort "error: index file not found; aborting" if not File.exists? "index"
-
-    config = ConfigData.new
-    all_files = (Dir.entries(".") -
-                 [".", "..", ".clayoven", "design"]).reject { |entry|
-      config.ignore.any? { |pattern| %r{#{pattern}} =~ entry }
-    }
-
-    abort "error: design/template.slim file not found; aborting" if not
-      Dir.entries("design").include? "template.slim"
-
-    index_files = ["index"] + all_files.select { |file| /\.index$/ =~ file }
-    content_files = all_files - index_files
-    topics = index_files.map { |file| file.split(".index")[0] }.uniq
-
-    # Next, look for stray files
-    (content_files.reject { |file| topics.include? (file.split(":", 2)[0]) })
-      .each { |stray_entry|
-      content_files = content_files - [stray_entry]
-      puts "warning: #{stray_entry} is a stray file or directory; ignored"
-    }
-
-    index_pages = index_files.map { |filename| IndexPage.new(filename) }
-    content_pages = content_files.map { |filename| ContentPage.new(filename) }
-
-    # First, fill in all the page attributes
-    (index_pages + content_pages).each { |page|
-      page.title, page.body = (IO.read page.filename).split("\n\n", 2)
-    }
-
-    # Compute the indexfill for indexes
-    topics.each { |topic|
-      topic_index = index_pages.select { |page| page.topic == topic }[0]
-      topic_index.indexfill = content_pages.select { |page|
-        page.topic == topic }.sort { |a, b| b.timestamp <=> a.timestamp }
-    }
-
-    (index_pages + content_pages).each { |page| page.render topics }
-  end
 end

--- a/lib/clayoven/claytext.rb
+++ b/lib/clayoven/claytext.rb
@@ -1,72 +1,74 @@
-class Paragraph
-  attr_accessor :content, :first, :type
+module ClayOven
+    class Paragraph
+        attr_accessor :content, :first, :type
 
-  def initialize(content)
-    @content = content
-    @first = false
-    @type = :plain
-  end
+        def initialize(content)
+            @content = content
+            @first = false
+            @type = :plain
+        end
 
-  def is_first?
-    @first
-  end
-end
-
-module ClayText
-  def self.process!(body)
-    htmlescape_rules = {
-      "&" => "&amp;",
-      "\"" => "&quot;",
-      "'" => "&#39;",
-      "<" => "&lt;",
-      ">" => "&gt;"
-    }.freeze
-
-    paragraph_types = [:plain, :emailquote, :codeblock, :header, :footer]
-    paragraph_rules = {
-      Proc.new { |line| line.start_with? "&gt; " } => lambda { |paragraph|
-        paragraph.type = :emailquote },
-      Proc.new { |line| line.start_with? "    " } => lambda { |paragraph|
-        paragraph.type = :codeblock },
-      Proc.new { |line| /^\[\d+\]: / =~ line } => lambda { |paragraph|
-        paragraph.content.gsub!(%r{^(\[\d+\]:) (.*://(.*))}) {
-          "#{$1} <a href=\"#{$2}\">#{$3[0, 64]}#{%{...} if $3.length > 67}</a>"
-        }
-        paragraph.type = :footer
-      }
-    }.freeze
-
-    # First, htmlescape the body text
-    body.gsub!(/[&"'<>]/, htmlescape_rules)
-
-    paragraphs = []
-    body.split("\n\n").each { |content|
-      paragraphs << Paragraph.new(content)
-    }
-
-    paragraphs[0].first = true
-    if paragraphs[0].content.start_with? "(" and
-        paragraphs[0].content.end_with? ")"
-      paragraphs[0].type = :header
+        def is_first?
+            @first
+        end
     end
 
-    # Paragraph-level processing
-    paragraphs.each { |paragraph|
-      paragraph_rules.each { |proc_match, lambda_cb|
-        if paragraph.content.lines.all? &proc_match
-          lambda_cb.call paragraph
+    module ClayText
+        def self.process!(body)
+            htmlescape_rules = {
+                "&" => "&amp;",
+                "\"" => "&quot;",
+                "'" => "&#39;",
+                "<" => "&lt;",
+                ">" => "&gt;"
+            }.freeze
+
+            paragraph_types = [:plain, :emailquote, :codeblock, :header, :footer]
+            paragraph_rules = {
+                Proc.new { |line| line.start_with? "&gt; " } => lambda { |paragraph|
+                    paragraph.type = :emailquote },
+                Proc.new { |line| line.start_with? "    " } => lambda { |paragraph|
+                    paragraph.type = :codeblock },
+                Proc.new { |line| /^\[\d+\]: / =~ line } => lambda { |paragraph|
+                    paragraph.content.gsub!(%r{^(\[\d+\]:) (.*://(.*))}) {
+                        "#{$1} <a href=\"#{$2}\">#{$3[0, 64]}#{%{...} if $3.length > 67}</a>"
+                    }
+                    paragraph.type = :footer
+                }
+            }.freeze
+
+            # First, htmlescape the body text
+            body.gsub!(/[&"'<>]/, htmlescape_rules)
+
+            paragraphs = []
+            body.split("\n\n").each { |content|
+                paragraphs << Paragraph.new(content)
+            }
+
+            paragraphs[0].first = true
+            if paragraphs[0].content.start_with? "(" and
+                    paragraphs[0].content.end_with? ")"
+                paragraphs[0].type = :header
+            end
+
+            # Paragraph-level processing
+            paragraphs.each { |paragraph|
+                paragraph_rules.each { |proc_match, lambda_cb|
+                    if paragraph.content.lines.all? &proc_match
+                        lambda_cb.call paragraph
+                    end
+                }
+            }
+
+            # Generate is_*? methods for Paragraph
+            Paragraph.class_eval {
+                paragraph_types.each { |type|
+                    define_method("is_#{type.to_s}?") { @type == type }
+                }
+            }
+
+            body = paragraphs.map(&:content).join("\n\n")
+            paragraphs
         end
-      }
-    }
-
-    # Generate is_*? methods for Paragraph
-    Paragraph.class_eval {
-      paragraph_types.each { |type|
-        define_method("is_#{type.to_s}?") { @type == type }
-      }
-    }
-
-    body = paragraphs.map(&:content).join("\n\n")
-    paragraphs
-  end
+    end
 end

--- a/lib/clayoven/config.rb
+++ b/lib/clayoven/config.rb
@@ -1,24 +1,26 @@
 require 'yaml'
 
-class ConfigData
-  attr_accessor :rootpath, :rcpath, :ignorepath, :rc, :ignore
+module ClayOven
+    class ConfigData
+        attr_accessor :rootpath, :rcpath, :ignorepath, :rc, :ignore
 
-  def initialize
-    @rootpath = ".clayoven"
-    @rcpath = File.expand_path "~/.clayovenrc"
-    @ignorepath = "#{rootpath}/ignore"
-    @ignore = ["\\.html$", "~$", "^.\#", "^\#.*\#$",
-               "^\\.git$", "^\\.gitignore$", "^\\.htaccess$"]
-    @rc = nil
+        def initialize
+            @rootpath = ".clayoven"
+            @rcpath = File.expand_path "~/.clayovenrc"
+            @ignorepath = "#{rootpath}/ignore"
+            @ignore = ["\\.html$", "~$", "^.\#", "^\#.*\#$",
+                       "^\\.git$", "^\\.gitignore$", "^\\.htaccess$"]
+            @rc = nil
 
-    Dir.mkdir @rootpath if not Dir.exists? @rootpath
-    if File.exists? @ignorepath
-      @ignore = IO.read(@ignorepath).split("\n")
-    else
-      File.open(@ignorepath, "w") { |ignoreio|
-        ignoreio.write @ignore.join("\n") }
-      puts "[NOTE] #{@ignorepath} populated with sane defaults"
+            Dir.mkdir @rootpath if not Dir.exists? @rootpath
+            if File.exists? @ignorepath
+                @ignore = IO.read(@ignorepath).split("\n")
+            else
+                File.open(@ignorepath, "w") { |ignoreio|
+                    ignoreio.write @ignore.join("\n") }
+                puts "[NOTE] #{@ignorepath} populated with sane defaults"
+            end
+            @rc = YAML.load_file @rcpath if File.exists? @rcpath
+        end
     end
-    @rc = YAML.load_file @rcpath if File.exists? @rcpath
-  end
 end

--- a/lib/clayoven/httpd.rb
+++ b/lib/clayoven/httpd.rb
@@ -1,24 +1,26 @@
 require 'webrick'
 
-module Httpd
-  def self.start
-    port = 8000
-    callback = Proc.new { |req, res|
-      if %r{^/$} =~ req.path_info
-        res.set_redirect WEBrick::HTTPStatus::Found, "index.html"
-      end
-      if %r{^/([^.]*)$} =~ req.path_info
-        res.set_redirect WEBrick::HTTPStatus::Found, "#{$1}.html"
-      end
-    }
+module ClayOven
+    module Httpd
+        def self.start
+            port = 8000
+            callback = Proc.new { |req, res|
+                if %r{^/$} =~ req.path_info
+                    res.set_redirect WEBrick::HTTPStatus::Found, "index.html"
+                end
+                if %r{^/([^.]*)$} =~ req.path_info
+                    res.set_redirect WEBrick::HTTPStatus::Found, "#{$1}.html"
+                end
+            }
 
-    server = WEBrick::HTTPServer.new(:Port            => port,
-                                     :RequestCallback => callback,
-                                     :DocumentRoot    => Dir.pwd)
+            server = WEBrick::HTTPServer.new(:Port            => port,
+                                             :RequestCallback => callback,
+                                             :DocumentRoot    => Dir.pwd)
 
-    puts "clayoven serving at: http://localhost:#{port}"
+            puts "clayoven serving at: http://localhost:#{port}"
 
-    trap(:INT) { server.shutdown }
-    server.start
-  end
+            trap(:INT) { server.shutdown }
+            server.start
+        end
+    end
 end

--- a/lib/clayoven/imapd.rb
+++ b/lib/clayoven/imapd.rb
@@ -1,43 +1,45 @@
 require 'net/imap'
 require_relative 'config'
 
-class Mail
-  attr_accessor :filename, :date, :msgid
+module ClayOven
+    class Mail
+        attr_accessor :filename, :date, :msgid
 
-  def initialize(filename, date, msgid)
-    @filename = filename
-    @date = date
-    @msgid = msgid
-  end
-end
+        def initialize(filename, date, msgid)
+            @filename = filename
+            @date = date
+            @msgid = msgid
+        end
+    end
 
-module Imapd
-  def self.poll
-    config = ConfigData.new
-    abort "error: #{config.rcpath} not found; aborting" if not config.rc
-    mails = []
-    server = Net::IMAP.new(config.rc["server"],
-                           {:port => config.rc["port"], :ssl => config.rc["ssl"]})
-    trap(:INT) { exit 1 }
-    server.login config.rc["username"], config.rc["password"]
-    puts "[NOTE] LOGIN successful"
-    server.examine "INBOX"
-    server.search(["ALL"]).each { |id|
-      message = server.fetch(id, ["ENVELOPE", "RFC822.TEXT"])[0]
-      if message.attr["ENVELOPE"].sender[0].mailbox == "artagnon" and
-          message.attr["ENVELOPE"].sender[0].host == "gmail.com" and
-          message.attr["ENVELOPE"].sender[0].name == "Ramkumar Ramachandra"
-        date = message.attr["ENVELOPE"].date
-        msgid = message.attr["ENVELOPE"].message_id
-        title, filename = message.attr["ENVELOPE"].subject.split(" # ")
-        next if File.exists? filename
-        File.open(filename, "w") { |targetio|
-          targetio.write([title, message.attr["RFC822.TEXT"].delete("\r")].join "\n\n")
-        }
-        mails << Mail.new(filename, date, msgid)
-      end
-    }
-    server.disconnect
-    mails
-  end
+    module Imapd
+        def self.poll
+            config = ConfigData.new
+            abort "error: #{config.rcpath} not found; aborting" if not config.rc
+            mails = []
+            server = Net::IMAP.new(config.rc["server"],
+                                   {:port => config.rc["port"], :ssl => config.rc["ssl"]})
+            trap(:INT) { exit 1 }
+            server.login config.rc["username"], config.rc["password"]
+            puts "[NOTE] LOGIN successful"
+            server.examine "INBOX"
+            server.search(["ALL"]).each { |id|
+                message = server.fetch(id, ["ENVELOPE", "RFC822.TEXT"])[0]
+                if message.attr["ENVELOPE"].sender[0].mailbox == "artagnon" and
+                        message.attr["ENVELOPE"].sender[0].host == "gmail.com" and
+                        message.attr["ENVELOPE"].sender[0].name == "Ramkumar Ramachandra"
+                    date = message.attr["ENVELOPE"].date
+                    msgid = message.attr["ENVELOPE"].message_id
+                    title, filename = message.attr["ENVELOPE"].subject.split(" # ")
+                    next if File.exists? filename
+                    File.open(filename, "w") { |targetio|
+                        targetio.write([title, message.attr["RFC822.TEXT"].delete("\r")].join "\n\n")
+                    }
+                    mails << Mail.new(filename, date, msgid)
+                end
+            }
+            server.disconnect
+            mails
+        end
+    end
 end


### PR DESCRIPTION
To prevent collisions with any other modules in global
namespaces. For instance the module `Mail` collides
with the ruby library [mail](https://github.com/mikel/mail).

This does messes up with git blame almost everywhere,
because of the indentation.
